### PR TITLE
TravisCI for doxygen published to gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+sudo: false
+
+branches:
+  only:
+    - master
+
+addons:
+  apt:
+    packages:
+      - doxygen
+
+script:
+  - doxygen nicp/nicp/Doxyfile
+
+deploy:
+  provider: pages
+  skip_cleanup: true
+  local_dir: html
+  github_token: $GH_REPO_TOKEN
+  on:
+    branch: master
+


### PR DESCRIPTION
adds .travis.yml that:
- runs doxygen on nicp/nicp/Doxyfile
- publishes html result on gh-pages
- run only on master branch