### PR TITLE
Automatic doxygen to gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,3 @@ deploy:
   github_token: $GH_REPO_TOKEN
   on:
     branch: master
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+sudo: false
+
+branches:
+  only:
+    - master
+
+addons:
+  apt:
+    packages:
+      - doxygen
+
+script:
+  - doxygen nicp/nicp/Doxyfile
+
+deploy:
+  provider: pages
+  skip_cleanup: true
+  local_dir: html
+  github_token: $GH_REPO_TOKEN
+  on:
+    branch: master
+

--- a/nicp/nicp/Doxyfile
+++ b/nicp/nicp/Doxyfile
@@ -1210,7 +1210,7 @@ SERVER_BASED_SEARCH    = NO
 # If the GENERATE_LATEX tag is set to YES (the default) Doxygen will
 # generate Latex output.
 
-GENERATE_LATEX         = YES
+GENERATE_LATEX         = NO
 
 # The LATEX_OUTPUT tag is used to specify where the LaTeX docs will be put.
 # If a relative path is entered the value of OUTPUT_DIRECTORY will be


### PR DESCRIPTION
Merging this and taking additional steps (below) would:
- automatically generate doxygen docs
- publish docs to gh-pages (available then at https://yorsh87.github.io/nicp/)

Example can be seen here:
https://bmegli.github.io/nicp/

This pull request:
- adds .travis.yml with instructions for CI
- disables LaTex documentation generation in Doxyfile

The additional setup needed:

1. Add clean `gh-pages` branch to your repository
```bash
git checkout --orphan gh-pages
git rm -rf .
echo "my gh-pages branch" > README.md
git add .
git commit -a -m "clean gh-pages branch"
git push origin gh-pages
```
2.  Sign up for [Travis CI](https://travis-ci.org/) and enable your project
3.  Generate  [personal access tokens](https://github.com/settings/tokens) with `public_repo` scope
4.  Add this token in [Travis CI](https://travis-ci.org/) -> `Your Project` -> `Settings` -> `Environment Variables` as `GH_REPO_TOKEN`
5. Merge the pull request (this will also trigger documentation build).

Troubleshoot if needed watching [Travis CI](https://travis-ci.org/) output for your project.

Your documentation would be available at:
https://yorsh87.github.io/nicp/

Just close this PR if you are not interested.