### PR TITLE
Check for _minDistance <= d <= _maxDistance once

### DIFF
--- a/nicp/nicp/parallelcylindricalpointprojector.cpp
+++ b/nicp/nicp/parallelcylindricalpointprojector.cpp
@@ -52,7 +52,6 @@ namespace nicp {
       int x, y;
       float d;
       if(!_project(x, y, d, *point) ||
-	 d < _minDistance || d > _maxDistance ||
 	 x < 0 || x >= indexImage.cols ||
 	 y < 0 || y >= indexImage.rows) {
 	continue;

--- a/nicp/nicp/pinholepointprojector.cpp
+++ b/nicp/nicp/pinholepointprojector.cpp
@@ -52,7 +52,6 @@ namespace nicp {
       int x, y;
       float d;
       if(!_project(x, y, d, *point) ||
-	 d < _minDistance || d > _maxDistance ||
 	 x < 0 || x >= indexImage.cols ||
 	 y < 0 || y >= indexImage.rows)
 	continue;

--- a/nicp/nicp/sphericalpointprojector.cpp
+++ b/nicp/nicp/sphericalpointprojector.cpp
@@ -51,7 +51,6 @@ namespace nicp {
       int x, y;
       float d;
       if(!_project(x, y, d, *point) ||
-	 d < _minDistance || d > _maxDistance ||
 	 x < 0 || x >= indexImage.cols ||
 	 y < 0 || y >= indexImage.rows) {
 	continue;


### PR DESCRIPTION
When projecting in:
- pinhole point projector
- spherical point projector
- parallel cylindrical point projector 

test for  _minDistance <= d <= _maxDistance is made twice for every point:
- in _project
- in project (calling _project)

Example from pinhole point projector:

``` C++
 inline bool _project(int &x, int &y, float &d, const Point &p) const {
      Eigen::Vector4f ip = _KRt * p;
      d = ip.coeff(2);
      if(d < _minDistance || d > _maxDistance) //this already tests and returns false
	return false;
      ip *= (1.0f / d);
      x = (int)round(ip.coeff(0));
      y = (int)round(ip.coeff(1)); 
      return true;
}
```

``` C++
void PinholePointProjector::project(IntImage &indexImage,
				      DepthImage &depthImage, 
				      const PointVector &points) const {
    assert(_imageRows && _imageCols && "PinholePointProjector: _imageRows and _imageCols are zero");
    
    //... 

    for(size_t i = 0; i < points.size(); i++, point++) {
      int x, y;
      float d;
      if(!_project(x, y, d, *point) ||
	 d < _minDistance || d > _maxDistance || //this test for every point was already made
	 x < 0 || x >= indexImage.cols ||
	 y < 0 || y >= indexImage.rows)
	continue;

      // ...

      }
    }
}
```